### PR TITLE
[TEA-56] Deploy Frontend

### DIFF
--- a/.github/workflows/frontend-deployment.yaml
+++ b/.github/workflows/frontend-deployment.yaml
@@ -1,0 +1,53 @@
+name: Deploy Frontend
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'frontend/**'
+
+jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    outputs:
+      artifact-id: ${{ steps.artifact-upload.outputs.artifact-id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            frontend
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+      - name: Install dependencies
+        run: npm install
+      - name: Build app
+        run: npm run build
+        env:
+          VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
+      - name: Upload build as artifact
+        uses: actions/upload-artifact@v4
+        id: artifact-upload
+        with:
+          name: frontend-artifact
+          path: './frontend/dist'
+          if-no-files-found: error
+          retention-days: 1
+
+  ping-server:
+    needs: build-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke Webhook
+        uses: johannes-huther/webhook.sh@v1
+        env:
+          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          webhook_secret: ${{ secrets.WEBHOOK_SECRET }}
+          data: '{"artifact-id": "${{ needs.build-frontend.outputs.artifact-id }}", "needs-parity": true}'


### PR DESCRIPTION
### In this PR, I'm adding/changing the following:

- Added a GitHub workflow for frontend CI/CD
 - Added relevant GH secrets

### Testing my changes:

The workflow will only run upon changes to the main branch and then only if the changes are to the frontend. Thus, it can only be fully tested after the PR is merged; however, it was tested on a personal repo that you can check out [here](https://github.com/angelajfisher/static-deployment-test).

### Notes:

The vast majority of the work done for this PR was on the DevOps side, which is not reflected in the repo itself. To see the details of the server-side implementation, expand the details below.

<details>
  <summary><b>Expand to See DevOps Details</b></summary>
<h3>ASM/LTM F5 Implementation:</h3>

Added a proxy for the pool of redundant webservers and for the webhook port:
![ASM](https://github.com/CommuniTEAM/CommuniTEA/assets/31549337/ae1fbbca-e01e-415f-82f4-d8d571ecaa59)


Added an auto-redirect for http port 80 to https port 443:
![80 to 443 redirect](https://github.com/CommuniTEAM/CommuniTEA/assets/31549337/8f82b57f-3658-40de-be0d-165831010c34)

</details>

[Related Jira Ticket](https://communiteam.atlassian.net/browse/TEA-56)
