### PR TITLE
[TEA-75] Fix Swagger UI in Production

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -59,7 +60,7 @@ func (a *API) dbConn(ctx context.Context) (*pgxpool.Conn, error) {
 	conn, err := a.DBPool.Acquire(ctx)
 	if err != nil {
 		log.Println(fmt.Errorf("could not acquire db connection: %w", err))
-		return nil, status.Wrap(fmt.Errorf(internalErrMsg), status.Internal)
+		return nil, status.Wrap(errors.New(internalErrMsg), status.Internal)
 	}
 	return conn, nil
 }

--- a/backend/api/api_test.go
+++ b/backend/api/api_test.go
@@ -58,7 +58,7 @@ func (suite *TestSuite) SetupSuite() {
 	}
 
 	api := &api.API{DBPool: dbPool, Auth: authenticator}
-	suite.server = httptest.NewServer(router.NewRouter(api))
+	suite.server = httptest.NewServer(router.NewRouter(api, "test"))
 
 	suite.errBody, err = os.ReadFile("_testdata/error_response.json")
 	if err != nil {

--- a/backend/api/locations.go
+++ b/backend/api/locations.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -33,12 +34,12 @@ func (a *API) CreateCity() usecase.Interactor {
 
 			// If the token was invalid or nonexistent then userData will be nil
 			if userData == nil {
-				return status.Wrap(fmt.Errorf("you must be logged in to perform this action"), status.Unauthenticated)
+				return status.Wrap(errors.New("you must be logged in to perform this action"), status.Unauthenticated)
 			}
 
 			// Verify that the user has the 'admin' role
 			if userData.Role != adminRole {
-				return status.Wrap(fmt.Errorf("you do not have permission to perform this action"), status.PermissionDenied)
+				return status.Wrap(errors.New("you do not have permission to perform this action"), status.PermissionDenied)
 			}
 
 			conn, err := a.dbConn(ctx)
@@ -53,13 +54,13 @@ func (a *API) CreateCity() usecase.Interactor {
 			_, err = a.getLocationID(input.CityName, input.StateCode)
 			if err == nil {
 				// If err is nil then the location already exists
-				return status.Wrap(fmt.Errorf("location already exists"), status.AlreadyExists)
+				return status.Wrap(errors.New("location already exists"), status.AlreadyExists)
 			}
 
 			newUUID, err := uuid.NewRandom()
 			if err != nil {
 				log.Println(fmt.Errorf("could not generate new uuid: %w", err))
-				return status.Wrap(fmt.Errorf(internalErrMsg), status.Internal)
+				return status.Wrap(errors.New(internalErrMsg), status.Internal)
 			}
 
 			inputArgs := db.CreateCityParams{
@@ -71,7 +72,7 @@ func (a *API) CreateCity() usecase.Interactor {
 			*output, err = queries.CreateCity(ctx, inputArgs)
 			if err != nil {
 				log.Println(fmt.Errorf("failed to create city: %w", err))
-				return status.Wrap(fmt.Errorf(internalErrMsg), status.Internal)
+				return status.Wrap(errors.New(internalErrMsg), status.Internal)
 			}
 
 			return nil
@@ -106,10 +107,10 @@ func (a *API) GetCity() usecase.Interactor {
 			*output, err = queries.GetCity(ctx, input.ID)
 			if err != nil {
 				if strings.Contains(err.Error(), "no rows") {
-					return status.Wrap(fmt.Errorf("no city with that id"), status.NotFound)
+					return status.Wrap(errors.New("no city with that id"), status.NotFound)
 				}
 				log.Println(fmt.Errorf("could not get city: %w", err))
-				return status.Wrap(fmt.Errorf(internalErrMsg), status.Internal)
+				return status.Wrap(errors.New(internalErrMsg), status.Internal)
 			}
 
 			return nil
@@ -143,7 +144,7 @@ func (a *API) GetAllCitiesInState() usecase.Interactor {
 			output.Cities, err = queries.GetAllCitiesInState(ctx, input.StateCode)
 			if err != nil {
 				log.Println(fmt.Errorf("could not get all cities in state: %w", err))
-				return status.Wrap(fmt.Errorf(internalErrMsg), status.Internal)
+				return status.Wrap(errors.New(internalErrMsg), status.Internal)
 			}
 
 			return nil
@@ -161,7 +162,7 @@ func (a *API) GetAllCitiesInState() usecase.Interactor {
 // in the database.
 func (a *API) GetAllCities() usecase.Interactor {
 	response := usecase.NewInteractor(
-		func(ctx context.Context, input defaultInput, output *citiesOutput) error {
+		func(ctx context.Context, _ defaultInput, output *citiesOutput) error {
 			conn, err := a.dbConn(ctx)
 			if err != nil {
 				return err
@@ -173,7 +174,7 @@ func (a *API) GetAllCities() usecase.Interactor {
 			output.Cities, err = queries.GetAllCities(ctx)
 			if err != nil {
 				log.Println(fmt.Errorf("could not get all cities: %w", err))
-				return status.Wrap(fmt.Errorf(internalErrMsg), status.Internal)
+				return status.Wrap(errors.New(internalErrMsg), status.Internal)
 			}
 
 			return nil
@@ -200,11 +201,11 @@ func (a *API) UpdateCity() usecase.Interactor {
 			userData := a.Auth.ValidateJWT(input.AccessToken)
 
 			if userData == nil {
-				return status.Wrap(fmt.Errorf("you must be logged in to perform this action"), status.Unauthenticated)
+				return status.Wrap(errors.New("you must be logged in to perform this action"), status.Unauthenticated)
 			}
 
 			if userData.Role != adminRole {
-				return status.Wrap(fmt.Errorf("you do not have permission to perform this action"), status.PermissionDenied)
+				return status.Wrap(errors.New("you do not have permission to perform this action"), status.PermissionDenied)
 			}
 
 			conn, err := a.dbConn(ctx)
@@ -219,23 +220,23 @@ func (a *API) UpdateCity() usecase.Interactor {
 			city, err := queries.GetCity(ctx, input.ID)
 			if err != nil {
 				if strings.Contains(err.Error(), "no rows") {
-					return status.Wrap(fmt.Errorf("no city with that id"), status.NotFound)
+					return status.Wrap(errors.New("no city with that id"), status.NotFound)
 				}
 				log.Println(fmt.Errorf("could not get city: %w", err))
-				return status.Wrap(fmt.Errorf(internalErrMsg), status.Internal)
+				return status.Wrap(errors.New(internalErrMsg), status.Internal)
 			}
 
 			// Check that the new city name won't conflict
 			_, err = a.getLocationID(input.Name, city.State)
 			if err == nil {
 				// If err is nil then a city with the new name already exists
-				return status.Wrap(fmt.Errorf("could not update: a city with that name already exists"), status.AlreadyExists)
+				return status.Wrap(errors.New("could not update: a city with that name already exists"), status.AlreadyExists)
 			}
 
 			*output, err = queries.UpdateCityName(ctx, db.UpdateCityNameParams{ID: input.ID, Name: input.Name})
 			if err != nil {
 				log.Println("could not update city name: %w", err)
-				return status.Wrap(fmt.Errorf(internalErrMsg), status.Internal)
+				return status.Wrap(errors.New(internalErrMsg), status.Internal)
 			}
 
 			return nil
@@ -264,11 +265,11 @@ func (a *API) DeleteCity() usecase.Interactor {
 			userData := a.Auth.ValidateJWT(input.AccessToken)
 
 			if userData == nil {
-				return status.Wrap(fmt.Errorf("you must be logged in to perform this action"), status.Unauthenticated)
+				return status.Wrap(errors.New("you must be logged in to perform this action"), status.Unauthenticated)
 			}
 
 			if userData.Role != adminRole {
-				return status.Wrap(fmt.Errorf("you do not have permission to perform this action"), status.PermissionDenied)
+				return status.Wrap(errors.New("you do not have permission to perform this action"), status.PermissionDenied)
 			}
 
 			conn, err := a.dbConn(ctx)
@@ -282,10 +283,10 @@ func (a *API) DeleteCity() usecase.Interactor {
 			err = queries.DeleteCity(ctx, input.ID)
 			if err != nil {
 				if strings.Contains(err.Error(), "fkey") {
-					return status.Wrap(fmt.Errorf("cannot delete a location that is in use by other data"), status.Aborted)
+					return status.Wrap(errors.New("cannot delete a location that is in use by other data"), status.Aborted)
 				}
 				log.Println(fmt.Errorf("could not delete city: %w", err))
-				return status.Wrap(fmt.Errorf(internalErrMsg), status.Internal)
+				return status.Wrap(errors.New(internalErrMsg), status.Internal)
 			}
 			output.Message = successMsg
 			return nil
@@ -312,7 +313,7 @@ func (a *API) GetAllStates() usecase.Interactor {
 	}
 
 	response := usecase.NewInteractor(
-		func(ctx context.Context, input defaultInput, output *statesOutput) error {
+		func(ctx context.Context, _ defaultInput, output *statesOutput) error {
 			conn, err := a.dbConn(ctx)
 			if err != nil {
 				return err
@@ -324,7 +325,7 @@ func (a *API) GetAllStates() usecase.Interactor {
 			output.States, err = queries.GetAllStates(ctx)
 			if err != nil {
 				log.Println(fmt.Errorf("could not get all states: %w", err))
-				return status.Wrap(fmt.Errorf(internalErrMsg), status.Internal)
+				return status.Wrap(errors.New(internalErrMsg), status.Internal)
 			}
 
 			return nil
@@ -354,7 +355,7 @@ func (a *API) getLocationID(cityName string, stateCode string) (uuid.UUID, error
 		State: stateCode,
 	})
 	if err != nil {
-		return uuid.UUID{}, status.Wrap(fmt.Errorf("location does not exist"), status.InvalidArgument)
+		return uuid.UUID{}, status.Wrap(errors.New("location does not exist"), status.InvalidArgument)
 	}
 
 	return locationID, nil

--- a/backend/api/wikiteadia.go
+++ b/backend/api/wikiteadia.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	db "github.com/CommuniTEAM/CommuniTEA/db/sqlc"
@@ -32,7 +33,7 @@ func (a *API) CreateTea() usecase.Interactor {
 
 		// If the token was invalid or nonexistent then userData will be nil
 		if userData == nil {
-			return status.Wrap(fmt.Errorf("you must be logged in to perform this action"), status.Unauthenticated)
+			return status.Wrap(errors.New("you must be logged in to perform this action"), status.Unauthenticated)
 		}
 
 		conn, err := a.dbConn(ctx)

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -61,7 +61,7 @@ func main() {
 	endpoints := &api.API{DBPool: dbPool, Auth: authenticator}
 
 	// Initialize router
-	s := router.NewRouter(endpoints)
+	s := router.NewRouter(endpoints, Env)
 
 	// Configure and start the server
 	const serverTimeout = 5

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -68,17 +68,13 @@ func addEndpoints(s *web.Service, endpoints *api.API) *web.Service {
 	s.Get("/teas/{published}", endpoints.GetAllTeas())
 	s.Post("/teas", endpoints.CreateTea())
 
-	// Swagger UI endpoint at /docs
-	s.Docs("/docs", swgui.New)
-	s.Handle("/", http.RedirectHandler("/docs", http.StatusSeeOther))
-
 	return s
 }
 
 // NewRouter creates a custom router for the http server in line with
 // openapi specifications. It bundles the included api endpoints into
 // the Swagger UI in the browser, available at /docs.
-func NewRouter(endpoints *api.API) http.Handler {
+func NewRouter(endpoints *api.API, envType string) http.Handler {
 	// Initialize openAPI 3.1 reflector
 	reflector := openapi31.NewReflector()
 
@@ -128,6 +124,18 @@ func NewRouter(endpoints *api.API) http.Handler {
 
 	// Add API endpoints to router
 	addEndpoints(s, endpoints)
+
+	// Swagger UI endpoint at /docs
+	s.Docs("/docs", swgui.New)
+	s.Handle("/", http.RedirectHandler(
+		func(env string) string {
+			if env == "prod" {
+				return "/api/docs"
+			}
+			return "/docs"
+		}(envType),
+		http.StatusSeeOther,
+	))
 
 	return s
 }

--- a/backend/router/router_test.go
+++ b/backend/router/router_test.go
@@ -23,7 +23,7 @@ func TestNewRouter(t *testing.T) {
 	}
 
 	endpoints := &api.API{DBPool: mockDBPool, Auth: authenticator}
-	r := router.NewRouter(endpoints, "test")
+	r := router.NewRouter(endpoints, "prod")
 
 	req, err := http.NewRequest(http.MethodGet, "/docs", nil)
 	if err != nil {

--- a/backend/router/router_test.go
+++ b/backend/router/router_test.go
@@ -17,13 +17,13 @@ func TestNewRouter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	authenicator, err := auth.NewAuthenticator()
+	authenticator, err := auth.NewAuthenticator()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	endpoints := &api.API{DBPool: mockDBPool, Auth: authenicator}
-	r := router.NewRouter(endpoints)
+	endpoints := &api.API{DBPool: mockDBPool, Auth: authenticator}
+	r := router.NewRouter(endpoints, "test")
 
 	req, err := http.NewRequest(http.MethodGet, "/docs", nil)
 	if err != nil {


### PR DESCRIPTION
### In this PR, I'm adding/changing the following:

- Fixed "/docs" redirect in production (now redirects to "/api/docs")
- Fixed the Swagger UI's "try out" feature in production so it now prepends "/api" to the endpoint's URI
- For some reason the linter got stricter overnight (I made no changes), so I fixed the new errors
  - Replaced all instances of `fmt.Errorf()` with `errors.New()` where there aren't any external errors to wrap
  - Replaced unused endpoint inputs (and one instance of context) with `_`
- Updated tests for `router.go` to include the changes made for prod 

### Notes

Codecov will be mad at this PR because I changed all of the 500 error lines, which cannot be covered by our tests. I didn't make any uncovered changes outside of a find & replace so please ignore.

[Related Jira Ticket](https://communiteam.atlassian.net/browse/TEA-75)
