### PR TITLE
TEA-80-Admin-delete-and-patch-endpoint

### DIFF
--- a/backend/api/_testdata/db_testdata_migration.sql
+++ b/backend/api/_testdata/db_testdata_migration.sql
@@ -92,3 +92,21 @@ insert into "teas" (
     175,
     false
 );
+
+insert into "teas" (
+    "id",
+    "name",
+    "img_url",
+    "description",
+    "brew_time",
+    "brew_temp",
+    "published"
+) values (
+    'c64ff5ab-7323-4142-9077-aea320c3c4cf',
+    'Black Tea',
+    'https://images.unsplash.com/photo-1605618826115-fb9e775cfb40?q=80&w=1779&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    'It is a black tea mix',
+    '20 minutes',
+    175,
+    false
+);

--- a/backend/api/wikiteadia.go
+++ b/backend/api/wikiteadia.go
@@ -54,6 +54,12 @@ type updateTeaInput struct {
 	Published bool `json:"published"`
 }
 
+type teaPublishedPatch struct {
+	defaultInput
+	ID        uuid.UUID `path:"id"`
+	Published bool      `json:"published"`
+}
+
 func (a *API) CreateTea() usecase.Interactor {
 	response := usecase.NewInteractor(func(ctx context.Context, input teaInput, output *db.Tea) error {
 		userData := a.Auth.ValidateJWT(input.AccessToken)
@@ -189,6 +195,63 @@ func (a *API) UpdateTea() usecase.Interactor {
 		status.Unauthenticated,
 		status.PermissionDenied,
 		status.AlreadyExists,
+		status.NotFound,
+	)
+
+	return response
+}
+
+func (a *API) PublishTea() usecase.Interactor {
+	response := usecase.NewInteractor(func(ctx context.Context, input teaPublishedPatch, output *db.Tea) error {
+		userData := a.Auth.ValidateJWT(input.AccessToken)
+
+		// If the token was invalid or nonexistent then userData will be nil
+		if userData == nil {
+			return status.Wrap(errors.New("you must be logged in to perform this action"), status.Unauthenticated)
+		}
+
+		if userData.Role != adminRole {
+			return status.Wrap(errors.New("you do not have permission to perform this action"), status.PermissionDenied)
+		}
+
+		conn, err := a.dbConn(ctx)
+		if err != nil {
+			return err
+		}
+		defer conn.Release()
+		queries := db.New(conn)
+
+		// Get original tea details
+		_, errCheck := queries.GetTea(ctx, input.ID)
+		if errCheck != nil {
+			if strings.Contains(errCheck.Error(), "no rows") {
+				return status.Wrap(errors.New("no tea with that id"), status.NotFound)
+			}
+			log.Println(fmt.Errorf("could not get tea: %w", errCheck))
+			return status.Wrap(errors.New(internalErrMsg), status.Internal)
+		}
+
+		teaParams := db.PublishTeaParams{
+			ID:        input.ID,
+			Published: input.Published,
+		}
+
+		*output, err = queries.PublishTea(ctx, teaParams)
+
+		if err != nil {
+			log.Println("could not publish tea information: %w", err)
+			return status.Wrap(errors.New(internalErrMsg), status.Internal)
+		}
+		return nil
+	})
+
+	response.SetTitle("Publish Tea")
+	response.SetDescription("Publish a new tea")
+	response.SetTags("Teas")
+	response.SetExpectedErrors(
+		status.InvalidArgument,
+		status.Unauthenticated,
+		status.PermissionDenied,
 		status.NotFound,
 	)
 

--- a/backend/api/wikiteadia_test.go
+++ b/backend/api/wikiteadia_test.go
@@ -421,7 +421,7 @@ func (suite *WikiteadiaTestSuite) TestPublishTea() {
 func (suite *WikiteadiaTestSuite) TestDeleteTea() {
 	t := suite.T()
 
-	teaID := "c64ff5ab-7323-4142-9077-aea320c3c4cc"
+	teaID := "c64ff5ab-7323-4142-9077-aea320c3c4cf"
 
 	// * Test 401 response & body
 	req, err := http.NewRequest(http.MethodDelete, suite.server.URL+"/teas/"+teaID, nil)

--- a/backend/api/wikiteadia_test.go
+++ b/backend/api/wikiteadia_test.go
@@ -289,3 +289,71 @@ func (suite *WikiteadiaTestSuite) TestUpdateTea() {
 
 	assertjson.Equal(t, expectedBody, respBody)
 }
+
+func (suite *WikiteadiaTestSuite) TestDeleteTea() {
+	t := suite.T()
+
+	teaID := "c64ff5ab-7323-4142-9077-aea320c3c4cc"
+
+	// * Test 401 response & body
+	req, err := http.NewRequest(http.MethodDelete, suite.server.URL+"/teas/"+teaID, nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assertjson.Equal(t, suite.errBody, respBody)
+
+	// * Test 403 response & body
+	req, err = http.NewRequest(http.MethodDelete, suite.server.URL+"/teas/"+teaID, nil)
+	require.NoError(t, err)
+
+	req.AddCookie(&http.Cookie{Name: "bearer-token", Value: suite.authTokens.user.Token})
+
+	resp, err = http.DefaultTransport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	respBody, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assertjson.Equal(t, suite.errBody, respBody)
+
+	// * Test 400 response
+	badInput := "lkashdflkj"
+
+	req, err = http.NewRequest(http.MethodDelete, suite.server.URL+"/teas/"+badInput, nil)
+	require.NoError(t, err)
+
+	req.AddCookie(&http.Cookie{Name: "bearer-token", Value: suite.authTokens.admin.Token})
+
+	resp, err = http.DefaultTransport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	// * Test 200 response & body
+	req, err = http.NewRequest(http.MethodDelete, suite.server.URL+"/teas/"+teaID, nil)
+	require.NoError(t, err)
+
+	req.AddCookie(&http.Cookie{Name: "bearer-token", Value: suite.authTokens.admin.Token})
+
+	resp, err = http.DefaultTransport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	respBody, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assertjson.Equal(t, suite.successBody, respBody)
+}

--- a/backend/api/wikiteadia_test.go
+++ b/backend/api/wikiteadia_test.go
@@ -290,6 +290,134 @@ func (suite *WikiteadiaTestSuite) TestUpdateTea() {
 	assertjson.Equal(t, expectedBody, respBody)
 }
 
+func (suite *WikiteadiaTestSuite) TestPublishTea() {
+	t := suite.T()
+
+	teaID := "c64ff5ab-7323-4142-9077-aea320c3c4cc"
+
+	reqBody := `{published": false}`
+
+	// * Check 401 response & body
+
+	req, err := http.NewRequest(http.MethodPatch, suite.server.URL+"/teas/"+teaID, bytes.NewBufferString(reqBody))
+
+	require.NoError(t, err)
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	respBody, err := io.ReadAll(resp.Body)
+
+	require.NoError(t, err)
+
+	require.NoError(t, resp.Body.Close())
+
+	assertjson.Equal(t, suite.errBody, respBody)
+
+	// * Check 403 response & body
+
+	req, err = http.NewRequest(http.MethodPatch, suite.server.URL+"/teas/"+teaID, bytes.NewBufferString(reqBody))
+
+	require.NoError(t, err)
+
+	req.AddCookie(&http.Cookie{Name: "bearer-token", Value: suite.authTokens.user.Token})
+
+	resp, err = http.DefaultTransport.RoundTrip(req)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	respBody, err = io.ReadAll(resp.Body)
+
+	require.NoError(t, err)
+
+	require.NoError(t, resp.Body.Close())
+
+	assertjson.Equal(t, suite.errBody, respBody)
+
+	// * Check 404 response & body
+
+	badInput := "248df4b7-aa70-47b8-a036-33ac447e668d" // fake uuid
+
+	req, err = http.NewRequest(http.MethodPatch, suite.server.URL+"/teas/"+badInput, bytes.NewBufferString(reqBody))
+
+	require.NoError(t, err)
+
+	req.AddCookie(&http.Cookie{Name: "bearer-token", Value: suite.authTokens.admin.Token})
+
+	resp, err = http.DefaultTransport.RoundTrip(req)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	respBody, err = io.ReadAll(resp.Body)
+
+	require.NoError(t, err)
+
+	require.NoError(t, resp.Body.Close())
+
+	assertjson.Equal(t, suite.errBody, respBody)
+
+	// * Check 400 response
+
+	badInputs := []string{
+		`{"published": apple}`,
+	}
+
+	for _, input := range badInputs {
+		req, err = http.NewRequest(http.MethodPatch, suite.server.URL+"/teas/"+teaID, bytes.NewBufferString(input))
+
+		require.NoError(t, err)
+
+		req.AddCookie(&http.Cookie{Name: "bearer-token", Value: suite.authTokens.admin.Token})
+
+		resp, err = http.DefaultTransport.RoundTrip(req)
+
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	}
+
+	// * Check 200 response & body
+
+	reqBody = `{"published": true}`
+
+	req, err = http.NewRequest(http.MethodPatch, suite.server.URL+"/teas/"+teaID, bytes.NewBufferString(reqBody))
+
+	require.NoError(t, err)
+
+	req.AddCookie(&http.Cookie{Name: "bearer-token", Value: suite.authTokens.admin.Token})
+
+	resp, err = http.DefaultTransport.RoundTrip(req)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	respBody, err = io.ReadAll(resp.Body)
+
+	require.NoError(t, err)
+
+	require.NoError(t, resp.Body.Close())
+
+	expectedBody := []byte(`{
+  "id": "c64ff5ab-7323-4142-9077-aea320c3c4cc",
+  "name": "Earl Grey",
+  "img_url": "https://images.unsplash.com/photo-1605618826115-fb9e775cfb40?q=80&w=1779&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "description": "It is a black tea mix",
+  "brew_time": "20 minutes",
+  "brew_temp": 175,
+  "published": true
+}`)
+
+	assertjson.Equal(t, expectedBody, respBody)
+}
+
 func (suite *WikiteadiaTestSuite) TestDeleteTea() {
 	t := suite.T()
 

--- a/backend/api/wikiteadia_test.go
+++ b/backend/api/wikiteadia_test.go
@@ -295,7 +295,7 @@ func (suite *WikiteadiaTestSuite) TestPublishTea() {
 
 	teaID := "c64ff5ab-7323-4142-9077-aea320c3c4cc"
 
-	reqBody := `{published": false}`
+	reqBody := `{"published": false}`
 
 	// * Check 401 response & body
 

--- a/backend/db/queries/wikiteadia.sql
+++ b/backend/db/queries/wikiteadia.sql
@@ -33,6 +33,12 @@ set
 where "id" = $1
 returning *;
 
+-- name: PublishTea :one
+update teas
+set "published" = $2
+where "id" = $1
+returning *;
+
 -- name: DeleteTea :exec
 delete from teas
 where id = $1;

--- a/backend/db/sqlc/wikiteadia.sql.go
+++ b/backend/db/sqlc/wikiteadia.sql.go
@@ -505,6 +505,33 @@ func (q *Queries) GetTeas(ctx context.Context, published bool) ([]Tea, error) {
 	return items, nil
 }
 
+const publishTea = `-- name: PublishTea :one
+update teas
+set "published" = $2
+where "id" = $1
+returning id, name, img_url, description, brew_time, brew_temp, published
+`
+
+type PublishTeaParams struct {
+	ID        uuid.UUID `json:"id"`
+	Published bool      `json:"published"`
+}
+
+func (q *Queries) PublishTea(ctx context.Context, arg PublishTeaParams) (Tea, error) {
+	row := q.db.QueryRow(ctx, publishTea, arg.ID, arg.Published)
+	var i Tea
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.ImgUrl,
+		&i.Description,
+		&i.BrewTime,
+		&i.BrewTemp,
+		&i.Published,
+	)
+	return i, err
+}
+
 const updateTea = `-- name: UpdateTea :one
 update teas
 set

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -69,6 +69,7 @@ func addEndpoints(s *web.Service, endpoints *api.API) *web.Service {
 	s.Get("/teas/{published}", endpoints.GetAllTeas())
 	s.Post("/teas", endpoints.CreateTea())
 	s.Put("/teas/{id}", endpoints.UpdateTea())
+	s.Delete("/teas/{id}", endpoints.DeleteTea())
 
 	return s
 }

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -69,6 +69,7 @@ func addEndpoints(s *web.Service, endpoints *api.API) *web.Service {
 	s.Get("/teas/{published}", endpoints.GetAllTeas())
 	s.Post("/teas", endpoints.CreateTea())
 	s.Put("/teas/{id}", endpoints.UpdateTea())
+	s.Patch("/teas/{id}", endpoints.PublishTea())
 	s.Delete("/teas/{id}", endpoints.DeleteTea())
 
 	return s


### PR DESCRIPTION
### In this PR, I'm adding/changing the following:

- Add delete endpoint and a patch endpoint
- Admin roles can delete teas and patch the published status of a tea.

### Please do the following to test my code:

1. create a tea
2. on an admin account use the patch endpoint to change the publish status to true
3. delete the tea

4. Run the test cases in the test file.

[Related Jira Ticket](https://communiteam.atlassian.net/browse/TEA-80)
